### PR TITLE
refactor: implement lazy initialization for common elements

### DIFF
--- a/src/app/components/layout-elements/header-bar-element.ts
+++ b/src/app/components/layout-elements/header-bar-element.ts
@@ -4,20 +4,25 @@ import {BaseElement} from '../base-element';
 import {step} from '../../../core/utils/decorators/step-decorator';
 
 export class HeaderElement extends BaseElement {
-    static messagesIcon = () => new HeaderElement(getLocator('.icon24-Message'));
-    static documentsIcon = () => new HeaderElement(getLocator('.icon24-Documents'));
+
+    private static messagesIcon = () => new HeaderElement(getLocator('.icon24-Message'));
+    private static documentsIcon = () => new HeaderElement(getLocator('.icon24-Documents'));
 
     constructor(locator: Locator, name?: string) {
         super(locator, name);
     }
 
     @step('Navigate to Messages page')
-    static async navigateToMessagesSection() {
-        await this.messagesIcon().click();
+    async navigateToMessagesSection() {
+        await HeaderElement.messagesIcon().click();
     }
 
     @step('Navigate to Documents page')
-    static async navigateToDocumentsSection() {
-        await this.documentsIcon().click();
+    async navigateToDocumentsSection() {
+        await HeaderElement.documentsIcon().click();
+    }
+
+    static getHeader(): HeaderElement {
+        return new HeaderElement(getLocator('#co-header'));
     }
 }

--- a/src/app/components/layout-elements/side-bar-element.ts
+++ b/src/app/components/layout-elements/side-bar-element.ts
@@ -1,33 +1,42 @@
 import {BaseElement} from '../base-element';
 import {Locator} from '@playwright/test';
-import {getLocatorByRole, getLocatorByText} from '../../../core/utils/locator-utils';
+import {getLocator, getLocatorByRole} from '../../../core/utils/locator-utils';
 import {step} from '../../../core/utils/decorators/step-decorator';
-import {HeaderElement} from './header-bar-element';
+import {ComponentsPage} from '../../pages/components-page';
 
 export class SideBarElement extends BaseElement {
 
-    static inboxSection = () => new SideBarElement(getLocatorByRole('treeitem').filter({hasText: 'Inbox'}));
-    static trashSection = () => new SideBarElement(getLocatorByRole('treeitem').filter({hasText: 'Trash'}));
-    static myDocumentsSection = () => new SideBarElement(getLocatorByText('My documents'), 'My Documents Section');
+    private inboxSection = () => new SideBarElement(getLocatorByRole('treeitem').filter({hasText: 'Inbox'}));
+    private trashSection = () => new SideBarElement(getLocatorByRole('treeitem').filter({hasText: 'Trash'}));
+    private myDocumentsSection = () => new SideBarElement(getLocatorByRole('treeitem').filter({hasText: 'My documents'}));
 
     constructor(locator: Locator, name?: string) {
         super(locator, name);
     }
 
     @step('Click on \'Inbox\' section')
-    static async navigateToInboxSection() {
-        await HeaderElement.navigateToMessagesSection();
+    async navigateToInboxSection() {
+        await ComponentsPage.header.navigateToMessagesSection();
         await this.inboxSection().click();
     }
 
     @step('Click on \'Trash\' section')
-    static async clickTrashSection() {
+    async clickTrashSection() {
         await this.trashSection().click();
     }
 
     @step('Navigate to My Documents section')
-    static async navigateToMyDocumentsSection() {
-        await HeaderElement.navigateToDocumentsSection();
+    async navigateToMyDocumentsSection() {
+        await ComponentsPage.header.navigateToDocumentsSection();
         await this.myDocumentsSection().click();
+    }
+
+    @step('Get Trash Section element')
+    async getTrashSection() {
+        return this.trashSection();
+    }
+
+    static getSideBar(): SideBarElement {
+        return new SideBarElement(getLocator('.appLeftPanel'));
     }
 }

--- a/src/app/components/layout-elements/tab-action-bar-element.ts
+++ b/src/app/components/layout-elements/tab-action-bar-element.ts
@@ -9,21 +9,21 @@ import {TableElement} from '../shared/table-element';
 
 export class TabActionBarElement extends BaseElement {
 
-    static checkIcon = () => new CheckboxElement(getLocator('.checkIcon'));
-    static spinnerElement = () => new SpinnerElement(getLocator('.loadingIcon'));
-    static deleteButton = () => new ButtonElement(getLocatorByTitle('Delete', {exact: true}));
-    static okButton = () => new ButtonElement(getLocator('#dialBtn_YES'));
-    static emptyMessagesTrashFolderText = () => new TableElement(getLocatorByRole('table').filter({hasText: 'No messages'}).first());
-    static emptyDocumentsTrashFolderText = () => new TableElement(getLocatorByRole('table').filter({hasText: 'no documents'}).first());
-    static selectAllButton = () => new TabActionBarElement(getLocatorByTitle('Select all').locator('div'));
-    static toTrashOption = () => new TabActionBarElement(getLocator('.icon.icon16-Trash'));
+    private checkIcon = () => new CheckboxElement(getLocator('.checkIcon'));
+    private spinnerElement = () => new SpinnerElement(getLocator('.loadingIcon'));
+    private deleteButton = () => new ButtonElement(getLocatorByTitle('Delete', {exact: true}));
+    private okButton = () => new ButtonElement(getLocator('#dialBtn_YES'));
+    private emptyMessagesTrashFolderText = () => new TableElement(getLocatorByRole('table').filter({hasText: 'No messages'}).first());
+    private emptyDocumentsTrashFolderText = () => new TableElement(getLocatorByRole('table').filter({hasText: 'no documents'}).first());
+    private selectAllButton = () => new TabActionBarElement(getLocatorByTitle('Select all').locator('div'));
+    private toTrashOption = () => new TabActionBarElement(getLocator('.icon.icon16-Trash'));
 
-    constructor(locator: Locator, name?: string) {
+    private constructor(locator: Locator, name?: string) {
         super(locator, name);
     }
 
     @step('Delete all items in Trash section')
-    static async deleteAllItemsFromTrashSection() {
+    async deleteAllItemsFromTrashSection() {
         await this.spinnerElement().waitForSpinnerToBeHidden();
 
         if (await this.emptyDocumentsTrashFolderText().isVisible()) return;
@@ -39,9 +39,13 @@ export class TabActionBarElement extends BaseElement {
     }
 
     @step('Move all items to trash section')
-    static async moveAllItemsToTrash() {
+    async moveAllItemsToTrash() {
         await this.spinnerElement().waitForSpinnerToBeHidden();
         await this.selectAllButton().click();
         await this.toTrashOption().click();
+    }
+
+    static getTabActionBar() {
+        return new TabActionBarElement(getLocator('.GCSDBRWBLV.toolbar'));
     }
 }

--- a/src/app/pages/components-page.ts
+++ b/src/app/pages/components-page.ts
@@ -1,0 +1,22 @@
+import {SideBarElement} from '../components/layout-elements/side-bar-element';
+import {TabActionBarElement} from '../components/layout-elements/tab-action-bar-element';
+import {getOrCreate} from '../../core/utils/init-utils';
+import {HeaderElement} from '../components/layout-elements/header-bar-element';
+
+export abstract class ComponentsPage {
+    private static _header: HeaderElement | null = null;
+    private static _sideBar: SideBarElement | null = null;
+    private static _tabActionBar: TabActionBarElement | null = null;
+
+    public static get header(): HeaderElement {
+        return getOrCreate(this._header, HeaderElement.getHeader);
+    }
+
+    public static get sideBar(): SideBarElement {
+        return getOrCreate(this._sideBar, SideBarElement.getSideBar);
+    }
+
+    public static get tabActionBar(): TabActionBarElement {
+        return getOrCreate(this._tabActionBar, TabActionBarElement.getTabActionBar);
+    }
+}

--- a/src/app/pages/documents-page.ts
+++ b/src/app/pages/documents-page.ts
@@ -1,15 +1,15 @@
 import {BaseElement} from '../components/base-element';
 import {getLocatorByTitle} from '../../core/utils/locator-utils';
-import {SideBarElement} from '../components/layout-elements/side-bar-element';
 import {step} from '../../core/utils/decorators/step-decorator';
+import {ComponentsPage} from './components-page';
 
 export class DocumentsPage {
 
     @step('Drag document to Trash')
     static async dragDocumentToTrash(fileName: string) {
         const sourceElement = await this.getDocumentByTitle(fileName);
-        const trashElement = SideBarElement.trashSection();
-        await sourceElement.dragAndDrop(trashElement);
+        const trashElement = ComponentsPage.sideBar.getTrashSection();
+        await sourceElement.dragAndDrop(await trashElement);
     }
 
     @step('Get document')

--- a/src/app/pages/messages-page.ts
+++ b/src/app/pages/messages-page.ts
@@ -15,6 +15,7 @@ import {JSHandle} from '@playwright/test';
 import {step} from '../../core/utils/decorators/step-decorator';
 
 export class MessagesPage {
+
     static recipientField = () => new InputElement(getLocatorByRole('row', {name: 'To', exact: true}).getByRole('textbox'));
     static mailSubjectField = () => new InputElement(getLocator('#mailSubject'));
     static newMailButton = () => new ButtonElement(getLocatorByTitle('New'));

--- a/src/core/utils/environment-helper.ts
+++ b/src/core/utils/environment-helper.ts
@@ -1,21 +1,20 @@
 import {step} from './decorators/step-decorator';
-import {TabActionBarElement} from '../../app/components/layout-elements/tab-action-bar-element';
-import {SideBarElement} from '../../app/components/layout-elements/side-bar-element';
+import {ComponentsPage} from '../../app/pages/components-page';
 
 export class EnvironmentHelper {
     @step('Clear messages page')
     public static async clearMessages() {
-        await SideBarElement.navigateToInboxSection();
-        await TabActionBarElement.moveAllItemsToTrash();
-        await SideBarElement.clickTrashSection();
-        await TabActionBarElement.deleteAllItemsFromTrashSection();
+        await ComponentsPage.sideBar.navigateToInboxSection();
+        await ComponentsPage.tabActionBar.moveAllItemsToTrash();
+        await ComponentsPage.sideBar.clickTrashSection();
+        await ComponentsPage.tabActionBar.deleteAllItemsFromTrashSection();
     }
 
     @step('Clear documents page')
     public static async clearDocuments(){
-        await SideBarElement.navigateToMyDocumentsSection();
-        await TabActionBarElement.moveAllItemsToTrash();
-        await SideBarElement.clickTrashSection();
-        await TabActionBarElement.deleteAllItemsFromTrashSection();
+        await ComponentsPage.sideBar.navigateToMyDocumentsSection();
+        await ComponentsPage.tabActionBar.moveAllItemsToTrash();
+        await ComponentsPage.sideBar.clickTrashSection();
+        await ComponentsPage.tabActionBar.deleteAllItemsFromTrashSection();
     }
 }

--- a/src/core/utils/init-utils.ts
+++ b/src/core/utils/init-utils.ts
@@ -1,0 +1,14 @@
+/**
+ * A utility function to initialize or return an existing instance.
+ * If the instance is null, it will create and return a new instance using the provided `create` function.
+ *
+ * @param instance The instance to check.
+ * @param create A function to create a new instance if `instance` is null.
+ * @returns The existing instance or a newly created instance.
+ */
+export function getOrCreate<T>(instance: T | null, create: () => T): T {
+    if (instance === null) {
+        instance = create();
+    }
+    return instance;
+}

--- a/src/tests/e2e/email-attachment-workflow.spec.ts
+++ b/src/tests/e2e/email-attachment-workflow.spec.ts
@@ -4,7 +4,7 @@ import {DocumentsPage} from '../../app/pages/documents-page';
 import {MessagesPage} from '../../app/pages/messages-page';
 import {LocatorAssertions} from '../../core/utils/assert-utils';
 import {EnvironmentHelper} from '../../core/utils/environment-helper';
-import {SideBarElement} from '../../app/components/layout-elements/side-bar-element';
+import {ComponentsPage} from '../../app/pages/components-page';
 
 test.beforeEach(async () => {
     await test.step('Clear the environment', async () => {
@@ -20,12 +20,12 @@ test('Email attachment workflow with drag-and-drop to trash', async ({}) => {
     const mailSubject = faker.lorem.words(3);
     const fileContent = faker.lorem.sentence();
 
-    await SideBarElement.navigateToInboxSection();
+    await ComponentsPage.sideBar.navigateToInboxSection();
     await MessagesPage.sendEmail(recipient, mailSubject, fileName, fileContent);
     await MessagesPage.saveAttachmentToDocuments(mailSubject, fileName);
 
-    await SideBarElement.navigateToMyDocumentsSection();
+    await ComponentsPage.sideBar.navigateToMyDocumentsSection();
     await DocumentsPage.dragDocumentToTrash(fileName);
-    await SideBarElement.clickTrashSection();
+    await ComponentsPage.sideBar.clickTrashSection();
     await LocatorAssertions.expectElementToBeVisible(await DocumentsPage.getDocumentByTitle(fileName));
 });


### PR DESCRIPTION
### What has been changed?
- **Refactored element initialization**: Moved common elements like `header`, `sideBar` and `tabActionBar` to a shared `CommonElements` class, which is responsible for lazy initialization. 
- **`getOrCreate` utility**: Created a helper function `getOrCreate` that ensures elements are only created when they are first accessed, improving the overall efficiency of the application.

### Why these changes?
- The refactor improves code modularity and maintainability by separating shared logic from page-specific behavior.
- It allows for better scalability in the future when additional pages or elements are added.

### Impact
- No breaking changes, but page initialization behavior is now more efficient and flexible.

